### PR TITLE
Add Podcasts feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ next-env.d.ts
 
 # claude code
 .claude/
+
+# references folder
+refs/

--- a/src/app/api/spotify/saved-episodes/route.ts
+++ b/src/app/api/spotify/saved-episodes/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { getSession } from '@/lib/session';
+import { createSpotifyClient } from '@/lib/spotify';
+
+export async function GET(request: Request) {
+  try {
+    const session = await getSession();
+
+    if (!session?.accessToken) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const limit = parseInt(searchParams.get('limit') || '50', 10);
+    const offset = parseInt(searchParams.get('offset') || '0', 10);
+
+    const spotify = createSpotifyClient(session.accessToken);
+    const savedEpisodes = await spotify.getSavedEpisodes(Math.min(limit, 50), offset);
+
+    return NextResponse.json(savedEpisodes);
+  } catch (error) {
+    console.error('Error fetching saved episodes:', error);
+    return NextResponse.json({ error: 'Failed to fetch saved episodes' }, { status: 500 });
+  }
+}

--- a/src/app/api/spotify/saved-shows/route.ts
+++ b/src/app/api/spotify/saved-shows/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { getSession } from '@/lib/session';
+import { createSpotifyClient } from '@/lib/spotify';
+
+export async function GET(request: Request) {
+  try {
+    const session = await getSession();
+
+    if (!session?.accessToken) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const limit = parseInt(searchParams.get('limit') || '50', 10);
+    const offset = parseInt(searchParams.get('offset') || '0', 10);
+
+    const spotify = createSpotifyClient(session.accessToken);
+    const savedShows = await spotify.getSavedShows(Math.min(limit, 50), offset);
+
+    return NextResponse.json(savedShows);
+  } catch (error) {
+    console.error('Error fetching saved shows:', error);
+    return NextResponse.json({ error: 'Failed to fetch saved shows' }, { status: 500 });
+  }
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -57,6 +57,7 @@ const navItemKeys = [
   { href: '/dashboard', key: 'home', icon: '⌂' },
   { href: '/dashboard/history', key: 'history', icon: '◎' },
   { href: '/dashboard/top', key: 'charts', icon: '▲' },
+  { href: '/dashboard/podcasts', key: 'podcasts', icon: '◉' },
   { href: '/dashboard/discover', key: 'discover', icon: '✦' },
   { href: '/dashboard/wrapped', key: 'wrapped', icon: '◆' },
   { href: '/dashboard/share', key: 'share', icon: '◫' },
@@ -79,7 +80,7 @@ export default function DashboardLayout({
   // Create navItems with translated labels
   const navItems = navItemKeys.map(item => ({
     ...item,
-    label: t(item.key as 'home' | 'history' | 'charts' | 'discover' | 'wrapped' | 'share'),
+    label: t(item.key as 'home' | 'history' | 'charts' | 'podcasts' | 'discover' | 'wrapped' | 'share'),
   }));
 
   useEffect(() => {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -8,7 +8,7 @@ import Link from 'next/link';
 import { GlowText, TerminalCard } from '@/components/crt';
 import { OnTourBadge } from '@/components/ui/OnTourBadge';
 import { UpcomingConcerts } from '@/components/dashboard/UpcomingConcerts';
-import { AIDiscoverIcon, ShareIcon, WrappedIcon, ConcertsIcon, ListeningStatsIcon } from '@/components/icons/FeatureIcons';
+import { AIDiscoverIcon, ShareIcon, WrappedIcon, ConcertsIcon, ListeningStatsIcon, PodcastsIcon } from '@/components/icons/FeatureIcons';
 import { useTourStatusBatch } from '@/hooks/useTourStatus';
 import { useGeolocation } from '@/hooks/useGeolocation';
 import { useTranslations } from 'next-intl';
@@ -376,7 +376,7 @@ export default function DashboardPage() {
         animate={{ opacity: 1, y: 0 }}
         transition={{ delay: 0.1 }}
       >
-        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
           <FeatureCard
             href="/dashboard/discover"
             title={t('featureCards.aiDiscover.title')}
@@ -400,6 +400,14 @@ export default function DashboardPage() {
             icon={<WrappedIcon />}
             gradient="from-[#ffb000] to-[#ff6600]"
             accentColor="#ffb000"
+          />
+          <FeatureCard
+            href="/dashboard/podcasts"
+            title={t('featureCards.podcasts.title')}
+            description={t('featureCards.podcasts.description')}
+            icon={<PodcastsIcon />}
+            gradient="from-[#a855f7] to-[#7c3aed]"
+            accentColor="#a855f7"
           />
           <FeatureCard
             href="/dashboard/share"

--- a/src/app/dashboard/podcasts/page.tsx
+++ b/src/app/dashboard/podcasts/page.tsx
@@ -1,0 +1,332 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { motion } from 'framer-motion';
+import Image from 'next/image';
+import { GlowText, TerminalCard, TerminalButton } from '@/components/crt';
+import { useTranslations } from 'next-intl';
+import { getLargestImage, type SpotifyShow, type SpotifyEpisode } from '@/lib/spotify';
+
+type Tab = 'shows' | 'episodes';
+
+interface SavedShow {
+  added_at: string;
+  show: SpotifyShow;
+}
+
+interface SavedEpisode {
+  added_at: string;
+  episode: SpotifyEpisode;
+}
+
+async function fetchSavedShows(limit: number, offset: number): Promise<{ items: SavedShow[]; total: number }> {
+  const res = await fetch(`/api/spotify/saved-shows?limit=${limit}&offset=${offset}`);
+  if (!res.ok) throw new Error('Failed to fetch');
+  return res.json();
+}
+
+async function fetchSavedEpisodes(limit: number, offset: number): Promise<{ items: SavedEpisode[]; total: number }> {
+  const res = await fetch(`/api/spotify/saved-episodes?limit=${limit}&offset=${offset}`);
+  if (!res.ok) throw new Error('Failed to fetch');
+  return res.json();
+}
+
+function formatDuration(ms: number): string {
+  const minutes = Math.floor(ms / 60000);
+  if (minutes >= 60) {
+    const hours = Math.floor(minutes / 60);
+    const mins = minutes % 60;
+    return `${hours}h ${mins}m`;
+  }
+  return `${minutes}m`;
+}
+
+function formatReleaseDate(dateStr: string): string {
+  const date = new Date(dateStr);
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+const ITEMS_PER_PAGE = 20;
+
+export default function PodcastsPage() {
+  const [activeTab, setActiveTab] = useState<Tab>('shows');
+  const [showsPage, setShowsPage] = useState(0);
+  const [episodesPage, setEpisodesPage] = useState(0);
+  const t = useTranslations('podcasts');
+  const tCommon = useTranslations('common');
+
+  const { data: showsData, isLoading: showsLoading } = useQuery({
+    queryKey: ['saved-shows-page', showsPage],
+    queryFn: () => fetchSavedShows(ITEMS_PER_PAGE, showsPage * ITEMS_PER_PAGE),
+  });
+
+  const { data: episodesData, isLoading: episodesLoading } = useQuery({
+    queryKey: ['saved-episodes-page', episodesPage],
+    queryFn: () => fetchSavedEpisodes(ITEMS_PER_PAGE, episodesPage * ITEMS_PER_PAGE),
+  });
+
+  const showsTotalPages = Math.ceil((showsData?.total || 0) / ITEMS_PER_PAGE);
+  const episodesTotalPages = Math.ceil((episodesData?.total || 0) / ITEMS_PER_PAGE);
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <motion.div
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="flex flex-wrap items-start justify-between gap-4"
+      >
+        <div>
+          <h1 className="font-terminal text-3xl">
+            <GlowText color="purple" size="sm">
+              <span className="text-muted-foreground">◉</span> {t('title')}
+            </GlowText>
+          </h1>
+          <p className="mt-1 font-mono text-sm text-muted-foreground">
+            {t('subtitle')}
+          </p>
+        </div>
+
+        {/* Tab Selector */}
+        <div className="flex gap-2">
+          <TerminalButton
+            variant={activeTab === 'shows' ? 'primary' : 'ghost'}
+            size="sm"
+            onClick={() => setActiveTab('shows')}
+          >
+            {t('tabs.shows')}
+          </TerminalButton>
+          <TerminalButton
+            variant={activeTab === 'episodes' ? 'primary' : 'ghost'}
+            size="sm"
+            onClick={() => setActiveTab('episodes')}
+          >
+            {t('tabs.episodes')}
+          </TerminalButton>
+        </div>
+      </motion.div>
+
+      {/* Content */}
+      {activeTab === 'shows' ? (
+        <motion.div
+          key="shows"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+        >
+          {showsLoading ? (
+            <TerminalCard>
+              <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+                {[...Array(10)].map((_, i) => (
+                  <div key={i} className="animate-pulse">
+                    <div className="aspect-square rounded-lg bg-secondary" />
+                    <div className="mt-2 h-4 w-3/4 rounded bg-secondary" />
+                    <div className="mt-1 h-3 w-1/2 rounded bg-secondary" />
+                  </div>
+                ))}
+              </div>
+            </TerminalCard>
+          ) : showsData?.items && showsData.items.length > 0 ? (
+            <>
+              <TerminalCard>
+                <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+                  {showsData.items.map((item, index) => (
+                    <motion.a
+                      key={item.show.id}
+                      href={item.show.external_urls.spotify}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      initial={{ opacity: 0, scale: 0.95 }}
+                      animate={{ opacity: 1, scale: 1 }}
+                      transition={{ delay: index * 0.03 }}
+                      className="group block"
+                    >
+                      <div className="relative aspect-square overflow-hidden rounded-lg border border-[rgba(168,85,247,0.2)] transition-all group-hover:border-[#a855f7] group-hover:shadow-[0_0_20px_rgba(168,85,247,0.3)]">
+                        {getLargestImage(item.show.images) ? (
+                          <Image
+                            src={getLargestImage(item.show.images)!}
+                            alt={item.show.name}
+                            fill
+                            quality={100}
+                            sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, (max-width: 1024px) 25vw, 20vw"
+                            className="object-cover transition-transform group-hover:scale-105"
+                          />
+                        ) : (
+                          <div className="flex h-full items-center justify-center bg-secondary">
+                            <span className="text-3xl opacity-30">🎙️</span>
+                          </div>
+                        )}
+                        {/* Episode count badge */}
+                        <div className="absolute bottom-2 right-2 rounded bg-background/80 px-2 py-0.5 font-mono text-xs text-[#a855f7]">
+                          {t('episodeCount', { count: item.show.total_episodes })}
+                        </div>
+                      </div>
+                      <p className="mt-2 truncate font-terminal text-sm text-foreground group-hover:text-[#a855f7]">
+                        {item.show.name}
+                      </p>
+                      <p className="truncate font-mono text-xs text-muted-foreground">
+                        {item.show.publisher}
+                      </p>
+                    </motion.a>
+                  ))}
+                </div>
+              </TerminalCard>
+
+              {/* Pagination */}
+              {showsTotalPages > 1 && (
+                <div className="flex items-center justify-center gap-4 pt-4">
+                  <TerminalButton
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setShowsPage((p) => Math.max(0, p - 1))}
+                    disabled={showsPage === 0}
+                  >
+                    {tCommon('prev')}
+                  </TerminalButton>
+                  <span className="font-mono text-sm text-muted-foreground">
+                    {tCommon('page', { current: showsPage + 1, total: showsTotalPages })}
+                  </span>
+                  <TerminalButton
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setShowsPage((p) => Math.min(showsTotalPages - 1, p + 1))}
+                    disabled={showsPage >= showsTotalPages - 1}
+                  >
+                    {tCommon('next')}
+                  </TerminalButton>
+                </div>
+              )}
+            </>
+          ) : (
+            <TerminalCard>
+              <div className="py-16 text-center">
+                <span className="text-5xl opacity-30">🎙️</span>
+                <p className="mt-4 font-terminal text-lg text-muted-foreground">{t('noShows')}</p>
+                <p className="mt-2 font-mono text-sm text-muted-foreground/70">
+                  Save podcasts on Spotify to see them here
+                </p>
+              </div>
+            </TerminalCard>
+          )}
+        </motion.div>
+      ) : (
+        <motion.div
+          key="episodes"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+        >
+          {episodesLoading ? (
+            <TerminalCard>
+              <div className="space-y-3">
+                {[...Array(10)].map((_, i) => (
+                  <div key={i} className="flex gap-3 animate-pulse">
+                    <div className="w-20 h-20 rounded-lg bg-secondary" />
+                    <div className="flex-1 space-y-2 py-1">
+                      <div className="h-4 w-3/4 rounded bg-secondary" />
+                      <div className="h-3 w-1/2 rounded bg-secondary" />
+                      <div className="h-3 w-1/4 rounded bg-secondary" />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </TerminalCard>
+          ) : episodesData?.items && episodesData.items.length > 0 ? (
+            <>
+              <TerminalCard>
+                <div className="space-y-3">
+                  {episodesData.items.map((item, index) => (
+                    <motion.a
+                      key={item.episode.id}
+                      href={item.episode.external_urls.spotify}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      initial={{ opacity: 0, x: -10 }}
+                      animate={{ opacity: 1, x: 0 }}
+                      transition={{ delay: index * 0.03 }}
+                      className="group flex gap-4 rounded-lg p-3 transition-colors hover:bg-[rgba(168,85,247,0.05)]"
+                    >
+                      {/* Episode image */}
+                      <div className="relative w-20 h-20 flex-shrink-0 overflow-hidden rounded-lg border border-[rgba(168,85,247,0.2)] transition-all group-hover:border-[#a855f7]">
+                        {getLargestImage(item.episode.images) ? (
+                          <Image
+                            src={getLargestImage(item.episode.images)!}
+                            alt={item.episode.name}
+                            fill
+                            quality={100}
+                            sizes="80px"
+                            className="object-cover transition-transform group-hover:scale-105"
+                          />
+                        ) : (
+                          <div className="flex h-full w-full items-center justify-center bg-secondary">
+                            <span className="text-xl opacity-30">🎙️</span>
+                          </div>
+                        )}
+                        {/* Play overlay */}
+                        <div className="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity">
+                          <span className="text-[#a855f7] text-2xl">▶</span>
+                        </div>
+                      </div>
+
+                      {/* Episode info */}
+                      <div className="flex-1 min-w-0 py-1">
+                        <p className="font-terminal text-base text-foreground group-hover:text-[#a855f7] line-clamp-1">
+                          {item.episode.name}
+                        </p>
+                        <p className="mt-1 font-mono text-sm text-muted-foreground line-clamp-1">
+                          {item.episode.show.name}
+                        </p>
+                        <div className="flex items-center gap-3 mt-2">
+                          <span className="inline-flex items-center gap-1 rounded-full bg-[rgba(168,85,247,0.1)] px-2 py-0.5 font-mono text-xs text-[#a855f7]">
+                            {formatDuration(item.episode.duration_ms)}
+                          </span>
+                          <span className="font-mono text-xs text-muted-foreground">
+                            {formatReleaseDate(item.episode.release_date)}
+                          </span>
+                        </div>
+                      </div>
+                    </motion.a>
+                  ))}
+                </div>
+              </TerminalCard>
+
+              {/* Pagination */}
+              {episodesTotalPages > 1 && (
+                <div className="flex items-center justify-center gap-4 pt-4">
+                  <TerminalButton
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setEpisodesPage((p) => Math.max(0, p - 1))}
+                    disabled={episodesPage === 0}
+                  >
+                    {tCommon('prev')}
+                  </TerminalButton>
+                  <span className="font-mono text-sm text-muted-foreground">
+                    {tCommon('page', { current: episodesPage + 1, total: episodesTotalPages })}
+                  </span>
+                  <TerminalButton
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setEpisodesPage((p) => Math.min(episodesTotalPages - 1, p + 1))}
+                    disabled={episodesPage >= episodesTotalPages - 1}
+                  >
+                    {tCommon('next')}
+                  </TerminalButton>
+                </div>
+              )}
+            </>
+          ) : (
+            <TerminalCard>
+              <div className="py-16 text-center">
+                <span className="text-5xl opacity-30">🎧</span>
+                <p className="mt-4 font-terminal text-lg text-muted-foreground">{t('noEpisodes')}</p>
+                <p className="mt-2 font-mono text-sm text-muted-foreground/70">
+                  Save episodes on Spotify to see them here
+                </p>
+              </div>
+            </TerminalCard>
+          )}
+        </motion.div>
+      )}
+    </div>
+  );
+}

--- a/src/components/crt/GlowText.tsx
+++ b/src/components/crt/GlowText.tsx
@@ -3,7 +3,7 @@
 import { cn } from '@/lib/utils';
 import { motion } from 'framer-motion';
 
-type GlowColor = 'phosphor' | 'cyan' | 'magenta' | 'amber';
+type GlowColor = 'phosphor' | 'cyan' | 'magenta' | 'amber' | 'purple';
 type GlowSize = 'sm' | 'md' | 'lg';
 
 interface GlowTextProps {
@@ -20,6 +20,7 @@ const colorClasses: Record<GlowColor, string> = {
   cyan: 'text-accent',
   magenta: 'text-[var(--crt-magenta)]',
   amber: 'text-[var(--crt-amber)]',
+  purple: 'text-[#a855f7]',
 };
 
 const sizeClasses: Record<GlowSize, string> = {

--- a/src/components/dashboard/LatestEpisodes.tsx
+++ b/src/components/dashboard/LatestEpisodes.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import Image from 'next/image';
+import { useQuery } from '@tanstack/react-query';
+import { motion } from 'framer-motion';
+import { TerminalCard } from '@/components/crt';
+import { useTranslations } from 'next-intl';
+import { getLargestImage, type SpotifyEpisode } from '@/lib/spotify';
+
+interface SavedEpisode {
+  added_at: string;
+  episode: SpotifyEpisode;
+}
+
+async function fetchSavedEpisodes(limit: number): Promise<{ items: SavedEpisode[]; total: number }> {
+  const res = await fetch(`/api/spotify/saved-episodes?limit=${limit}`);
+  if (!res.ok) throw new Error('Failed to fetch');
+  return res.json();
+}
+
+function formatDuration(ms: number): string {
+  const minutes = Math.floor(ms / 60000);
+  if (minutes >= 60) {
+    const hours = Math.floor(minutes / 60);
+    const mins = minutes % 60;
+    return `${hours}h ${mins}m`;
+  }
+  return `${minutes}m`;
+}
+
+function formatReleaseDate(dateStr: string): string {
+  const date = new Date(dateStr);
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+interface LatestEpisodesProps {
+  limit?: number;
+  showTitle?: boolean;
+}
+
+export function LatestEpisodes({ limit = 10, showTitle = true }: LatestEpisodesProps) {
+  const t = useTranslations('podcasts');
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['saved-episodes', limit],
+    queryFn: () => fetchSavedEpisodes(limit),
+  });
+
+  if (isLoading) {
+    return (
+      <TerminalCard title={showTitle ? "saved_episodes.data" : undefined} animate={false}>
+        <div className="space-y-3">
+          {[...Array(5)].map((_, i) => (
+            <div key={i} className="flex gap-3 animate-pulse">
+              <div className="w-16 h-16 rounded-lg bg-[#1a1a1a]" />
+              <div className="flex-1 space-y-2">
+                <div className="h-4 w-3/4 rounded bg-[#1a1a1a]" />
+                <div className="h-3 w-1/2 rounded bg-[#1a1a1a]" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </TerminalCard>
+    );
+  }
+
+  if (error) {
+    return (
+      <TerminalCard title={showTitle ? "saved_episodes.data" : undefined} animate={false}>
+        <div className="py-4 text-center">
+          <p className="font-terminal text-sm text-[#ff4444]">Error loading episodes</p>
+        </div>
+      </TerminalCard>
+    );
+  }
+
+  const episodes = data?.items || [];
+
+  if (episodes.length === 0) {
+    return (
+      <TerminalCard title={showTitle ? "saved_episodes.data" : undefined} animate={false}>
+        <div className="py-8 text-center">
+          <p className="font-terminal text-sm text-muted-foreground">{t('noEpisodes')}</p>
+        </div>
+      </TerminalCard>
+    );
+  }
+
+  return (
+    <TerminalCard title={showTitle ? "saved_episodes.data" : undefined} animate={false}>
+      <div className="space-y-3">
+        {episodes.map((item, index) => (
+          <motion.div
+            key={item.episode.id}
+            initial={{ opacity: 0, x: -10 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ delay: index * 0.05 }}
+          >
+            <a
+              href={item.episode.external_urls.spotify}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group flex gap-3 rounded-md p-2 transition-colors hover:bg-[rgba(168,85,247,0.05)]"
+            >
+              {/* Episode image */}
+              <div className="relative w-16 h-16 flex-shrink-0 overflow-hidden rounded-lg border border-[rgba(168,85,247,0.2)] transition-all group-hover:border-[#a855f7]">
+                {getLargestImage(item.episode.images) ? (
+                  <Image
+                    src={getLargestImage(item.episode.images)!}
+                    alt={item.episode.name}
+                    fill
+                    quality={100}
+                    sizes="64px"
+                    className="object-cover transition-transform group-hover:scale-105"
+                  />
+                ) : (
+                  <div className="flex h-full w-full items-center justify-center bg-[#1a1a1a]">
+                    <span className="text-lg opacity-30">🎙️</span>
+                  </div>
+                )}
+                {/* Play indicator */}
+                <div className="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <span className="text-[#a855f7] text-xl">▶</span>
+                </div>
+              </div>
+
+              {/* Episode info */}
+              <div className="flex-1 min-w-0">
+                <p className="truncate font-terminal text-sm text-foreground group-hover:text-[#a855f7]">
+                  {item.episode.name}
+                </p>
+                <p className="truncate font-mono text-xs text-muted-foreground">
+                  {item.episode.show.name}
+                </p>
+                <div className="flex items-center gap-2 mt-1">
+                  <span className="font-mono text-[10px] text-[#a855f7]">
+                    {formatDuration(item.episode.duration_ms)}
+                  </span>
+                  <span className="text-muted-foreground">•</span>
+                  <span className="font-mono text-[10px] text-muted-foreground">
+                    {formatReleaseDate(item.episode.release_date)}
+                  </span>
+                </div>
+              </div>
+            </a>
+          </motion.div>
+        ))}
+      </div>
+    </TerminalCard>
+  );
+}

--- a/src/components/dashboard/TopPodcasts.tsx
+++ b/src/components/dashboard/TopPodcasts.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import Image from 'next/image';
+import { useQuery } from '@tanstack/react-query';
+import { motion } from 'framer-motion';
+import { TerminalCard } from '@/components/crt';
+import { useTranslations } from 'next-intl';
+import { getLargestImage, type SpotifyShow } from '@/lib/spotify';
+
+interface SavedShow {
+  added_at: string;
+  show: SpotifyShow;
+}
+
+async function fetchSavedShows(limit: number): Promise<{ items: SavedShow[]; total: number }> {
+  const res = await fetch(`/api/spotify/saved-shows?limit=${limit}`);
+  if (!res.ok) throw new Error('Failed to fetch');
+  return res.json();
+}
+
+interface TopPodcastsProps {
+  limit?: number;
+  showTitle?: boolean;
+}
+
+export function TopPodcasts({ limit = 10, showTitle = true }: TopPodcastsProps) {
+  const t = useTranslations('podcasts');
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['saved-shows', limit],
+    queryFn: () => fetchSavedShows(limit),
+  });
+
+  if (isLoading) {
+    return (
+      <TerminalCard title={showTitle ? "saved_shows.data" : undefined} animate={false}>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-5">
+          {[...Array(5)].map((_, i) => (
+            <div key={i} className="animate-pulse">
+              <div className="aspect-square rounded-lg bg-[#1a1a1a]" />
+              <div className="mt-2 h-4 w-3/4 rounded bg-[#1a1a1a]" />
+            </div>
+          ))}
+        </div>
+      </TerminalCard>
+    );
+  }
+
+  if (error) {
+    return (
+      <TerminalCard title={showTitle ? "saved_shows.data" : undefined} animate={false}>
+        <div className="py-4 text-center">
+          <p className="font-terminal text-sm text-[#ff4444]">Error loading podcasts</p>
+        </div>
+      </TerminalCard>
+    );
+  }
+
+  const shows = data?.items || [];
+
+  if (shows.length === 0) {
+    return (
+      <TerminalCard title={showTitle ? "saved_shows.data" : undefined} animate={false}>
+        <div className="py-8 text-center">
+          <p className="font-terminal text-sm text-muted-foreground">{t('noShows')}</p>
+        </div>
+      </TerminalCard>
+    );
+  }
+
+  return (
+    <TerminalCard title={showTitle ? "saved_shows.data" : undefined} animate={false}>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-5">
+        {shows.map((item, index) => (
+          <motion.div
+            key={item.show.id}
+            initial={{ opacity: 0, scale: 0.95 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ delay: index * 0.05 }}
+          >
+            <a
+              href={item.show.external_urls.spotify}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group block"
+            >
+              {/* Show image */}
+              <div className="relative aspect-square overflow-hidden rounded-lg border border-[rgba(168,85,247,0.2)] transition-all group-hover:border-[#a855f7] group-hover:shadow-[0_0_15px_rgba(168,85,247,0.3)]">
+                {getLargestImage(item.show.images) ? (
+                  <Image
+                    src={getLargestImage(item.show.images)!}
+                    alt={item.show.name}
+                    fill
+                    quality={100}
+                    sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, 20vw"
+                    className="object-cover transition-transform group-hover:scale-105"
+                  />
+                ) : (
+                  <div className="flex h-full items-center justify-center bg-[#1a1a1a]">
+                    <span className="text-2xl opacity-30">🎙️</span>
+                  </div>
+                )}
+                {/* Rank badge */}
+                <div className="absolute left-2 top-2 flex h-6 w-6 items-center justify-center rounded-full bg-[#0a0a0a]/80 font-terminal text-xs text-[#a855f7]">
+                  {index + 1}
+                </div>
+                {/* Episode count badge */}
+                <div className="absolute bottom-2 right-2 rounded bg-[#0a0a0a]/80 px-1.5 py-0.5 font-mono text-[10px] text-[#a855f7]">
+                  {item.show.total_episodes} ep
+                </div>
+              </div>
+
+              {/* Show name */}
+              <p className="mt-2 truncate font-terminal text-sm text-foreground group-hover:text-[#a855f7]">
+                {item.show.name}
+              </p>
+
+              {/* Publisher */}
+              <p className="truncate font-mono text-xs text-muted-foreground">
+                {item.show.publisher}
+              </p>
+            </a>
+          </motion.div>
+        ))}
+      </div>
+    </TerminalCard>
+  );
+}
+
+export function TopPodcastsList({ limit = 5 }: TopPodcastsProps) {
+  const t = useTranslations('podcasts');
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['saved-shows', limit],
+    queryFn: () => fetchSavedShows(limit),
+  });
+
+  if (isLoading || error || !data?.items?.length) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2">
+      {data.items.slice(0, 5).map((item, index) => (
+        <motion.div
+          key={item.show.id}
+          initial={{ opacity: 0, x: -10 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ delay: index * 0.05 }}
+        >
+          <a
+            href={item.show.external_urls.spotify}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group flex items-center gap-3 rounded-md p-2 transition-colors hover:bg-[rgba(168,85,247,0.05)]"
+          >
+            {/* Rank */}
+            <span className="w-6 text-center font-terminal text-lg text-[#a855f7]">
+              {index + 1}
+            </span>
+
+            {/* Show image */}
+            <div className="relative h-10 w-10 flex-shrink-0 overflow-hidden rounded-lg border border-[rgba(168,85,247,0.2)]">
+              {getLargestImage(item.show.images) && (
+                <Image
+                  src={getLargestImage(item.show.images)!}
+                  alt={item.show.name}
+                  fill
+                  quality={100}
+                  sizes="40px"
+                  className="object-cover"
+                />
+              )}
+            </div>
+
+            {/* Show info */}
+            <div className="min-w-0 flex-1">
+              <p className="truncate font-terminal text-sm text-foreground group-hover:text-[#a855f7]">
+                {item.show.name}
+              </p>
+              <p className="truncate font-mono text-xs text-muted-foreground">
+                {item.show.publisher}
+              </p>
+            </div>
+
+            {/* Episode count */}
+            <span className="font-mono text-xs text-muted-foreground">
+              {t('episodeCount', { count: item.show.total_episodes })}
+            </span>
+          </a>
+        </motion.div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/icons/FeatureIcons.tsx
+++ b/src/components/icons/FeatureIcons.tsx
@@ -206,6 +206,66 @@ export function ShareIcon() {
   );
 }
 
+// Podcasts Icon - Microphone with pulsing sound waves
+export function PodcastsIcon() {
+  return (
+    <div className="relative w-8 h-8 flex items-center justify-center">
+      {/* Microphone base */}
+      <motion.div
+        className="absolute w-3.5 h-5 rounded-t-full"
+        style={{
+          background: "linear-gradient(180deg, #a855f7 0%, #7c3aed 100%)",
+          boxShadow: "0 0 10px rgba(168,85,247,0.5)",
+          top: "4px",
+        }}
+        animate={{ scale: [1, 1.05, 1] }}
+        transition={{ duration: 2, repeat: Infinity, ease: "easeInOut" }}
+      />
+      {/* Microphone stand */}
+      <div
+        className="absolute w-[2px] h-2 rounded-full"
+        style={{
+          background: "#a855f7",
+          bottom: "4px",
+        }}
+      />
+      <div
+        className="absolute w-3 h-[2px] rounded-full"
+        style={{
+          background: "#a855f7",
+          bottom: "4px",
+        }}
+      />
+      {/* Sound waves */}
+      {[0, 1, 2].map((i) => (
+        <motion.div
+          key={i}
+          className="absolute rounded-full border border-transparent"
+          style={{
+            width: 16 + i * 6,
+            height: 16 + i * 6,
+            borderTopColor: "#a855f7",
+            borderRightColor: "#a855f7",
+            transform: "rotate(45deg)",
+            top: 6 - i * 3,
+            right: 2 - i * 3,
+          }}
+          animate={{
+            opacity: [0.3, 0.8, 0.3],
+            scale: [0.95, 1.05, 0.95],
+          }}
+          transition={{
+            duration: 1.2,
+            repeat: Infinity,
+            ease: "easeInOut",
+            delay: i * 0.2,
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
 // Wrapped Icon - Spiral time rewind with sparkles
 export function WrappedIcon() {
   return (

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -102,6 +102,7 @@
       "home": "Home",
       "history": "History",
       "charts": "Charts",
+      "podcasts": "Podcasts",
       "discover": "Discover",
       "wrapped": "Wrapped",
       "share": "Share",
@@ -159,6 +160,10 @@
       "share": {
         "title": "Share",
         "description": "Create beautiful cards for Instagram Stories"
+      },
+      "podcasts": {
+        "title": "Podcasts",
+        "description": "View your saved shows and episodes"
       }
     }
   },
@@ -235,6 +240,9 @@
       "genres": {
         "title": "Your Top Genres"
       },
+      "topPodcasts": {
+        "title": "Your Top Podcasts"
+      },
       "listeningPatterns": {
         "title": "Your Listening Patterns",
         "peakTime": "Peak listening time:",
@@ -258,7 +266,9 @@
       "topArtist": "#1 Artist",
       "top5Artists": "Top 5 Artists",
       "topTrack": "#1 Track",
-      "statsCard": "Stats Card"
+      "statsCard": "Stats Card",
+      "topPodcast": "#1 Podcast",
+      "top5Podcasts": "Top 5 Podcasts"
     },
     "timeRange": "time_range",
     "download": "Download PNG",
@@ -270,6 +280,8 @@
       "top5Artists": "Top 5 Artists ({timeRange})",
       "myNumber1Track": "My #1 Track ({timeRange})",
       "myStats": "My Stats ({timeRange})",
+      "myNumber1Podcast": "My #1 Podcast ({timeRange})",
+      "top5Podcasts": "Top 5 Podcasts ({timeRange})",
       "timeListened": "Time Listened",
       "tracksPlayed": "Tracks Played",
       "artists": "Artists",
@@ -280,6 +292,19 @@
     "title": "Concerts",
     "subtitle": "Upcoming shows from your favorite artists",
     "tracking": "Tracking:"
+  },
+  "podcasts": {
+    "title": "Podcasts",
+    "subtitle": "Your saved shows and episodes",
+    "tabs": {
+      "shows": "Shows",
+      "episodes": "Episodes"
+    },
+    "episodeCount": "{count} episodes",
+    "noShows": "No saved podcasts yet",
+    "noEpisodes": "No saved episodes yet",
+    "byPublisher": "by {publisher}",
+    "duration": "{minutes}m"
   },
   "meta": {
     "title": "MyScrobble.fm | Your Spotify Dashboard",

--- a/src/messages/pt-BR.json
+++ b/src/messages/pt-BR.json
@@ -102,6 +102,7 @@
       "home": "Início",
       "history": "Histórico",
       "charts": "Rankings",
+      "podcasts": "Podcasts",
       "discover": "Descobrir",
       "wrapped": "Wrapped",
       "share": "Compartilhar",
@@ -159,6 +160,10 @@
       "share": {
         "title": "Compartilhar",
         "description": "Crie cards bonitos para Instagram Stories"
+      },
+      "podcasts": {
+        "title": "Podcasts",
+        "description": "Veja seus programas e episódios salvos"
       }
     }
   },
@@ -235,6 +240,9 @@
       "genres": {
         "title": "Seus Gêneros Favoritos"
       },
+      "topPodcasts": {
+        "title": "Seus Podcasts Favoritos"
+      },
       "listeningPatterns": {
         "title": "Seus Padrões de Audição",
         "peakTime": "Horário de pico:",
@@ -258,7 +266,9 @@
       "topArtist": "Artista #1",
       "top5Artists": "Top 5 Artistas",
       "topTrack": "Música #1",
-      "statsCard": "Card de Estatísticas"
+      "statsCard": "Card de Estatísticas",
+      "topPodcast": "Podcast #1",
+      "top5Podcasts": "Top 5 Podcasts"
     },
     "timeRange": "período",
     "download": "Baixar PNG",
@@ -270,6 +280,8 @@
       "top5Artists": "Top 5 Artistas ({timeRange})",
       "myNumber1Track": "Minha Música #1 ({timeRange})",
       "myStats": "Minhas Estatísticas ({timeRange})",
+      "myNumber1Podcast": "Meu Podcast #1 ({timeRange})",
+      "top5Podcasts": "Top 5 Podcasts ({timeRange})",
       "timeListened": "Tempo Ouvido",
       "tracksPlayed": "Músicas Tocadas",
       "artists": "Artistas",
@@ -280,6 +292,19 @@
     "title": "Shows",
     "subtitle": "Próximos shows dos seus artistas favoritos",
     "tracking": "Rastreando:"
+  },
+  "podcasts": {
+    "title": "Podcasts",
+    "subtitle": "Seus programas e episódios salvos",
+    "tabs": {
+      "shows": "Programas",
+      "episodes": "Episódios"
+    },
+    "episodeCount": "{count} episódios",
+    "noShows": "Nenhum podcast salvo ainda",
+    "noEpisodes": "Nenhum episódio salvo ainda",
+    "byPublisher": "por {publisher}",
+    "duration": "{minutes}min"
   },
   "meta": {
     "title": "MyScrobble.fm | Seu Painel do Spotify",


### PR DESCRIPTION
## Summary
- Add comprehensive Podcasts feature showing saved shows and latest episodes
- Integrate podcasts into Wrapped slides and Share card templates
- Add Spotify API endpoints for saved shows and episodes
- Add `getLargestImage` helper for high-quality podcast cover art
- Full i18n support (English and Portuguese)

## New Features
- **Podcasts Page** (`/dashboard/podcasts`): View saved shows in grid layout and saved episodes in list format with tabs and pagination
- **Wrapped Integration**: New "Your Top Podcasts" slide in the Wrapped experience
- **Purple Theme**: Distinctive purple (#a855f7) color scheme for podcast elements

## Files Added
- `src/app/api/spotify/saved-shows/route.ts`
- `src/app/api/spotify/saved-episodes/route.ts`
- `src/app/dashboard/podcasts/page.tsx`
- `src/components/dashboard/TopPodcasts.tsx`
- `src/components/dashboard/LatestEpisodes.tsx`

## Test plan
- [ ] Navigate to `/dashboard/podcasts` and verify shows/episodes load
- [ ] Test pagination on both tabs
- [ ] Check Wrapped slides include podcasts slide
- [ ] Verify Share page has podcast card templates
- [ ] Test Portuguese locale translations
- [ ] Verify high-quality podcast cover images