### PR TITLE
Add debug logging for email sending

### DIFF
--- a/src/lib/email/index.ts
+++ b/src/lib/email/index.ts
@@ -113,14 +113,20 @@ interface SendAccessGrantedEmailParams {
 
 export async function sendWelcomeEmail({ to, name, position, locale = 'en' }: SendWelcomeEmailParams) {
   const t = translations.welcome[locale] || translations.welcome.en;
+
+  console.log('[Email] Attempting to send welcome email to:', to);
+  console.log('[Email] RESEND_API_KEY exists:', !!process.env.RESEND_API_KEY);
+
   const resend = getResendClient();
 
   if (!resend) {
-    console.error('Resend client not initialized - missing API key');
-    return { success: false, error: new Error('Email service not configured') };
+    const errorMsg = 'Resend client not initialized - missing API key';
+    console.error('[Email]', errorMsg);
+    throw new Error(errorMsg);
   }
 
   try {
+    console.log('[Email] Sending email via Resend...');
     const { data, error } = await resend.emails.send({
       from: FROM_EMAIL,
       to,
@@ -129,28 +135,34 @@ export async function sendWelcomeEmail({ to, name, position, locale = 'en' }: Se
     });
 
     if (error) {
-      console.error('Failed to send welcome email:', error);
-      return { success: false, error };
+      console.error('[Email] Resend API error:', error);
+      throw error;
     }
 
-    console.log('Welcome email sent:', data);
+    console.log('[Email] Welcome email sent successfully:', data);
     return { success: true, data };
   } catch (error) {
-    console.error('Error sending welcome email:', error);
-    return { success: false, error };
+    console.error('[Email] Error sending welcome email:', error);
+    throw error;
   }
 }
 
 export async function sendAccessGrantedEmail({ to, name, locale = 'en' }: SendAccessGrantedEmailParams) {
   const t = translations.accessGranted[locale] || translations.accessGranted.en;
+
+  console.log('[Email] Attempting to send access granted email to:', to);
+  console.log('[Email] RESEND_API_KEY exists:', !!process.env.RESEND_API_KEY);
+
   const resend = getResendClient();
 
   if (!resend) {
-    console.error('Resend client not initialized - missing API key');
-    return { success: false, error: new Error('Email service not configured') };
+    const errorMsg = 'Resend client not initialized - missing API key';
+    console.error('[Email]', errorMsg);
+    throw new Error(errorMsg);
   }
 
   try {
+    console.log('[Email] Sending email via Resend...');
     const { data, error } = await resend.emails.send({
       from: FROM_EMAIL,
       to,
@@ -159,15 +171,15 @@ export async function sendAccessGrantedEmail({ to, name, locale = 'en' }: SendAc
     });
 
     if (error) {
-      console.error('Failed to send access granted email:', error);
-      return { success: false, error };
+      console.error('[Email] Resend API error:', error);
+      throw error;
     }
 
-    console.log('Access granted email sent:', data);
+    console.log('[Email] Access granted email sent successfully:', data);
     return { success: true, data };
   } catch (error) {
-    console.error('Error sending access granted email:', error);
-    return { success: false, error };
+    console.error('[Email] Error sending access granted email:', error);
+    throw error;
   }
 }
 


### PR DESCRIPTION
## Summary
- Add verbose logging to track email sending flow in production
- Log whether `RESEND_API_KEY` exists (without exposing the value)
- Fix error handling to throw instead of returning `{ success: false }`
- This ensures `.catch()` in the waitlist route properly catches failures

## How to debug
After deploying, check Vercel Logs for `[Email]` prefixed messages:
- `[Email] RESEND_API_KEY exists: false` → Key not set
- `[Email] RESEND_API_KEY exists: true` + error → API issue
- `[Email] Welcome email sent successfully:` → Working

## Test plan
- [x] Deploy to Vercel
- [ ] Sign up for waitlist
- [ ] Check Vercel logs for `[Email]` entries
- [ ] Verify email is sent or identify the failure point