### PR TITLE
Test email with Resend default sender

### DIFF
--- a/src/lib/email/index.ts
+++ b/src/lib/email/index.ts
@@ -13,7 +13,8 @@ function getResendClient(): Resend | null {
   return resendClient;
 }
 
-const FROM_EMAIL = 'MyScrobble <hello@myscrobble.fm>';
+// TODO: Change back to 'MyScrobble <hello@myscrobble.fm>' after debugging
+const FROM_EMAIL = 'MyScrobble <onboarding@resend.dev>';
 
 type Locale = 'en' | 'pt-BR';
 


### PR DESCRIPTION
## Summary
- Temporarily use `onboarding@resend.dev` to debug email sending issue
- Helps isolate whether the problem is domain-related or API/network related

## Next steps
- If email works: issue is with domain setup, contact Resend support
- If email still fails: issue is with API key or network

## TODO
- [ ] Change back to `hello@myscrobble.fm` after debugging