### PR TITLE
Await email sending in serverless function

### DIFF
--- a/src/app/api/waitlist/route.ts
+++ b/src/app/api/waitlist/route.ts
@@ -93,13 +93,19 @@ export async function POST(request: Request) {
 
     const position = count || 1;
 
-    // Send welcome email (don't await to not block the response)
-    sendWelcomeEmail({
-      to: email.toLowerCase(),
-      name: spotifyName || undefined,
-      position,
-      locale,
-    }).catch((err) => console.error('Failed to send welcome email:', err));
+    // Send welcome email - must await in serverless to prevent function termination
+    try {
+      await sendWelcomeEmail({
+        to: email.toLowerCase(),
+        name: spotifyName || undefined,
+        position,
+        locale,
+      });
+      console.log('[Waitlist] Welcome email sent successfully');
+    } catch (emailErr) {
+      // Log but don't fail the request if email fails
+      console.error('[Waitlist] Failed to send welcome email:', emailErr);
+    }
 
     return NextResponse.json({
       success: true,


### PR DESCRIPTION
## Summary
Fix email not sending due to serverless function termination.

## Problem
The email was being sent with fire-and-forget pattern:
```js
sendWelcomeEmail({...}).catch(err => console.error(err));
return NextResponse.json({...}); // Function returns immediately
```

Vercel terminates the serverless function as soon as the response is sent, before the fetch to Resend completes.

## Solution
Properly `await` the email sending so the function stays alive:
```js
try {
  await sendWelcomeEmail({...});
} catch (emailErr) {
  console.error(emailErr); // Log but don't fail request
}
return NextResponse.json({...});
```

## Test plan
- [ ] Deploy to Vercel
- [ ] Sign up for waitlist
- [ ] Check logs for `[Email] Resend response status:`
- [ ] Verify email is received