### PR TITLE
Restore official email sender address

### DIFF
--- a/src/lib/email/index.ts
+++ b/src/lib/email/index.ts
@@ -1,8 +1,7 @@
 // Using fetch directly instead of Resend SDK to avoid Vercel serverless issues
 const RESEND_API_URL = 'https://api.resend.com/emails';
 
-// TODO: Change back to 'MyScrobble <hello@myscrobble.fm>' after debugging
-const FROM_EMAIL = 'MyScrobble <onboarding@resend.dev>';
+const FROM_EMAIL = 'MyScrobble <hello@myscrobble.fm>';
 
 interface ResendEmailPayload {
   from: string;


### PR DESCRIPTION
## Summary
Switch back from test email to production email now that sending is working.

- `onboarding@resend.dev` → `hello@myscrobble.fm`

## Verified
- [x] Email sends successfully from verified domain