### PR TITLE
Fix footer overlapping success state on waitlist page

### DIFF
--- a/src/app/waitlist/page.tsx
+++ b/src/app/waitlist/page.tsx
@@ -377,8 +377,8 @@ export default function WaitlistPage() {
         {isSuccess && <Confetti />}
       </AnimatePresence>
 
-      {/* Main content - full viewport height */}
-      <div className="relative z-10 h-[100dvh] flex flex-col items-center justify-center px-4 md:px-6 py-8 md:py-12">
+      {/* Main content - minimum full viewport height, can grow on mobile */}
+      <div className="relative z-10 min-h-[100dvh] flex flex-col items-center justify-center px-4 md:px-6 py-8 md:py-12">
         {/* Logo */}
         <motion.div
           initial={{ opacity: 0, y: -20 }}


### PR DESCRIPTION
## Summary
Fix footer appearing on top of "you're on the list" content on mobile.

## Problem
The main content had `h-[100dvh]` (fixed height), but on mobile the success state content (position badge + share buttons) doesn't fit, causing the footer to overlap.

## Solution
Changed to `min-h-[100dvh]` so the content area:
- Fills the viewport when content is short (footer below fold)
- Grows to fit content when needed (footer pushed down naturally)