### PR TITLE
Add privacy policy page with i18n support

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,264 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { useTranslations } from 'next-intl';
+import Link from 'next/link';
+import { Footer } from '@/components/ui/Footer';
+
+// Flowing organic shape component (matching other pages)
+function FlowingShape({
+  className,
+  gradient,
+  delay = 0,
+  floatDirection = 'up'
+}: {
+  className?: string;
+  gradient: string;
+  delay?: number;
+  floatDirection?: 'up' | 'down' | 'left' | 'right';
+}) {
+  const floatAnimations = {
+    up: { y: [0, -30, 0], x: [0, 15, 0] },
+    down: { y: [0, 30, 0], x: [0, -15, 0] },
+    left: { x: [0, -30, 0], y: [0, 15, 0] },
+    right: { x: [0, 30, 0], y: [0, -15, 0] },
+  };
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, scale: 0.8 }}
+      animate={{
+        opacity: 1,
+        scale: 1,
+        ...floatAnimations[floatDirection],
+      }}
+      transition={{
+        opacity: { duration: 1.5, delay },
+        scale: { duration: 1.5, delay },
+        x: { duration: 12, repeat: Infinity, ease: 'easeInOut' },
+        y: { duration: 12, repeat: Infinity, ease: 'easeInOut' },
+      }}
+      className={className}
+    >
+      <motion.svg
+        viewBox="0 0 200 200"
+        className="w-full h-full"
+        animate={{
+          rotate: [0, 8, -8, 0],
+          scale: [1, 1.08, 0.95, 1],
+        }}
+        transition={{
+          duration: 18,
+          repeat: Infinity,
+          ease: 'easeInOut',
+        }}
+      >
+        <defs>
+          <linearGradient id={`grad-privacy-${gradient}`} x1="0%" y1="0%" x2="100%" y2="100%">
+            {gradient === 'purple-pink' && (
+              <>
+                <stop offset="0%" stopColor="#8B5CF6" />
+                <stop offset="50%" stopColor="#EC4899" />
+                <stop offset="100%" stopColor="#F59E0B" />
+              </>
+            )}
+            {gradient === 'teal-blue' && (
+              <>
+                <stop offset="0%" stopColor="#14B8A6" />
+                <stop offset="50%" stopColor="#3B82F6" />
+                <stop offset="100%" stopColor="#8B5CF6" />
+              </>
+            )}
+            {gradient === 'spotify' && (
+              <>
+                <stop offset="0%" stopColor="#1DB954" />
+                <stop offset="100%" stopColor="#14B8A6" />
+              </>
+            )}
+          </linearGradient>
+        </defs>
+        <path
+          d="M40,-62.6C52.2,-54.5,62.9,-43.9,69.8,-31.1C76.7,-18.3,79.8,-3.3,77.5,10.8C75.2,24.9,67.4,38.1,56.7,48.1C46,58.1,32.4,64.9,17.8,69.1C3.2,73.3,-12.4,74.9,-26.6,70.9C-40.8,66.9,-53.6,57.3,-63.1,45C-72.6,32.7,-78.8,17.7,-79.5,2.1C-80.2,-13.5,-75.4,-29.7,-66.1,-42.3C-56.8,-54.9,-43,-64,-28.8,-70.4C-14.6,-76.8,0,-80.5,13.8,-77.4C27.6,-74.3,27.8,-70.7,40,-62.6Z"
+          transform="translate(100 100)"
+          fill={`url(#grad-privacy-${gradient})`}
+        />
+      </motion.svg>
+    </motion.div>
+  );
+}
+
+// Section component for consistent styling
+function Section({
+  title,
+  children,
+  delay = 0
+}: {
+  title: string;
+  children: React.ReactNode;
+  delay?: number;
+}) {
+  return (
+    <motion.section
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5, delay }}
+      className="mb-8"
+    >
+      <h2 className="text-lg font-semibold text-foreground mb-3 flex items-center gap-2">
+        <span className="w-1 h-5 bg-gradient-to-b from-[#1DB954] to-[#14B8A6] rounded-full" />
+        {title}
+      </h2>
+      <div className="text-muted-foreground text-sm leading-relaxed space-y-3">
+        {children}
+      </div>
+    </motion.section>
+  );
+}
+
+export default function PrivacyPage() {
+  const t = useTranslations('privacy');
+
+  return (
+    <div className="min-h-screen bg-background relative overflow-hidden">
+      {/* Flowing organic shapes */}
+      <div className="fixed inset-0 pointer-events-none overflow-hidden">
+        <FlowingShape
+          className="absolute -top-16 md:-top-48 -right-16 md:-right-48 w-[180px] md:w-[600px] h-[180px] md:h-[600px] opacity-10 md:opacity-20"
+          gradient="purple-pink"
+          delay={0}
+          floatDirection="up"
+        />
+        <FlowingShape
+          className="absolute -bottom-12 md:-bottom-32 -left-12 md:-left-32 w-[140px] md:w-[400px] h-[140px] md:h-[400px] opacity-10 md:opacity-15"
+          gradient="teal-blue"
+          delay={0.2}
+          floatDirection="right"
+        />
+        <FlowingShape
+          className="absolute top-1/2 -right-8 md:-right-24 w-[100px] md:w-[300px] h-[100px] md:h-[300px] opacity-10 md:opacity-15"
+          gradient="spotify"
+          delay={0.4}
+          floatDirection="left"
+        />
+      </div>
+
+      {/* Header */}
+      <header className="relative z-10 border-b border-border/50 bg-white/60 dark:bg-white/5 backdrop-blur-xl">
+        <div className="max-w-3xl mx-auto px-6 py-4">
+          <div className="flex items-center justify-between">
+            <Link href="/" className="flex items-baseline gap-1">
+              <span className="text-lg font-bold text-foreground">MyScrobble</span>
+              <span className="text-sm text-muted-foreground">.fm</span>
+            </Link>
+            <Link
+              href="/"
+              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              {t('backToHome')}
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      {/* Content */}
+      <main className="relative z-10 max-w-3xl mx-auto px-6 py-12">
+        {/* Title */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6 }}
+          className="mb-10"
+        >
+          <h1 className="text-3xl md:text-4xl font-black text-foreground mb-3">
+            {t('title')}
+          </h1>
+          <p className="text-muted-foreground">
+            {t('lastUpdated')}: {t('lastUpdatedDate')}
+          </p>
+        </motion.div>
+
+        {/* Glass card container */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, delay: 0.1 }}
+          className="bg-white/60 dark:bg-white/10 backdrop-blur-xl rounded-2xl border border-border/50 p-6 md:p-8"
+        >
+          {/* Introduction */}
+          <Section title={t('sections.intro.title')} delay={0.2}>
+            <p>{t('sections.intro.content')}</p>
+          </Section>
+
+          {/* What We Collect */}
+          <Section title={t('sections.dataCollected.title')} delay={0.25}>
+            <p>{t('sections.dataCollected.intro')}</p>
+            <ul className="list-disc list-inside space-y-1 ml-2">
+              <li>{t('sections.dataCollected.item1')}</li>
+              <li>{t('sections.dataCollected.item2')}</li>
+              <li>{t('sections.dataCollected.item3')}</li>
+              <li>{t('sections.dataCollected.item4')}</li>
+            </ul>
+          </Section>
+
+          {/* How We Use It */}
+          <Section title={t('sections.howWeUse.title')} delay={0.3}>
+            <p>{t('sections.howWeUse.intro')}</p>
+            <ul className="list-disc list-inside space-y-1 ml-2">
+              <li>{t('sections.howWeUse.item1')}</li>
+              <li>{t('sections.howWeUse.item2')}</li>
+              <li>{t('sections.howWeUse.item3')}</li>
+            </ul>
+          </Section>
+
+          {/* Data Storage */}
+          <Section title={t('sections.dataStorage.title')} delay={0.35}>
+            <p>{t('sections.dataStorage.content')}</p>
+          </Section>
+
+          {/* Third Party Services */}
+          <Section title={t('sections.thirdParty.title')} delay={0.4}>
+            <p>{t('sections.thirdParty.intro')}</p>
+            <ul className="list-disc list-inside space-y-1 ml-2">
+              <li><strong>Spotify:</strong> {t('sections.thirdParty.spotify')}</li>
+              <li><strong>Supabase:</strong> {t('sections.thirdParty.supabase')}</li>
+              <li><strong>Google Gemini:</strong> {t('sections.thirdParty.gemini')}</li>
+            </ul>
+          </Section>
+
+          {/* Your Rights */}
+          <Section title={t('sections.yourRights.title')} delay={0.45}>
+            <p>{t('sections.yourRights.intro')}</p>
+            <ul className="list-disc list-inside space-y-1 ml-2">
+              <li>{t('sections.yourRights.item1')}</li>
+              <li>{t('sections.yourRights.item2')}</li>
+              <li>{t('sections.yourRights.item3')}</li>
+            </ul>
+          </Section>
+
+          {/* Data Retention */}
+          <Section title={t('sections.retention.title')} delay={0.5}>
+            <p>{t('sections.retention.content')}</p>
+          </Section>
+
+          {/* Contact */}
+          <Section title={t('sections.contact.title')} delay={0.55}>
+            <p>
+              {t('sections.contact.content')}{' '}
+              <a
+                href="mailto:hello@myscrobble.fm"
+                className="text-[#1DB954] hover:underline"
+              >
+                hello@myscrobble.fm
+              </a>
+            </p>
+          </Section>
+        </motion.div>
+      </main>
+
+      {/* Footer */}
+      <div className="relative z-10">
+        <Footer />
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/Footer.tsx
+++ b/src/components/ui/Footer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useTranslations } from 'next-intl';
+import Link from 'next/link';
 
 interface FooterProps {
   className?: string;
@@ -18,17 +19,26 @@ export function Footer({ className = '' }: FooterProps) {
             <span className="text-lg font-bold text-foreground">MyScrobble</span>
             <span className="text-sm text-muted-foreground">.fm</span>
           </div>
-          <p className="text-sm text-muted-foreground">
-            {t('madeWith')} <span className="text-red-500">&#10084;</span> {t('by')}{' '}
-            <a
-              href="https://lucasbittar.dev"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-foreground hover:text-primary transition-colors"
+          <div className="flex items-center gap-4">
+            <Link
+              href="/privacy"
+              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
             >
-              Lucas
-            </a>
-          </p>
+              {t('privacy')}
+            </Link>
+            <span className="text-muted-foreground/30">|</span>
+            <p className="text-sm text-muted-foreground">
+              {t('madeWith')} <span className="text-red-500">&#10084;</span> {t('by')}{' '}
+              <a
+                href="https://lucasbittar.dev"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-foreground hover:text-primary transition-colors"
+              >
+                Lucas
+              </a>
+            </p>
+          </div>
         </div>
 
         {/* Disclaimer section */}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -467,6 +467,7 @@
   "footer": {
     "madeWith": "Made with",
     "by": "by",
+    "privacy": "Privacy Policy",
     "disclaimer": "MyScrobble.fm is an independent music analytics tool. I have no official affiliation with Last.fm or Spotify. The term \"Scrobble\" is used descriptively for the culture of tracking the music we love.",
     "tagline": "Transforming your data into visual insights"
   },
@@ -505,7 +506,7 @@
     "headlinePart1": "Tonight's show is",
     "headlineHighlight": "sold out",
     "subheadline": "But you're on the guest list for the next one",
-    "explanation": "MyScrobble is in early access with limited spots. We're working on expanding capacity.",
+    "explanation": "MyScrobble.fm is in early access with limited spots. We're working on expanding capacity.",
     "cta": "Get Your Backstage Pass",
     "emailPlaceholder": "your@email.com",
     "successPart1": "You're on",
@@ -515,14 +516,67 @@
     "position": "#{position} in line",
     "shareTitle": "Share with friends",
     "shareDescription": "Help us grow and move up the list",
-    "twitterText": "Just discovered MyScrobble - a beautiful Spotify dashboard with AI recommendations and concert discovery. Check it out!",
-    "whatsappText": "Check out MyScrobble - it shows your Spotify stats, finds concerts, and gives AI music recommendations!",
+    "twitterText": "Just discovered MyScrobble.fm - a beautiful Spotify dashboard with AI recommendations and concert discovery. Check it out!",
+    "whatsappText": "Check out MyScrobble.fm - it shows your Spotify stats, finds concerts, and gives AI music recommendations!",
     "copyLink": "Copy Link",
     "linkCopied": "Link copied!",
     "invalidEmail": "Please enter a valid email address",
     "yourPosition": "Your Position",
     "backToHome": "Back to home",
     "signingUpAs": "Signing up as"
+  },
+  "privacy": {
+    "title": "Privacy Policy",
+    "backToHome": "Back to Home",
+    "lastUpdated": "Last updated",
+    "lastUpdatedDate": "January 2026",
+    "sections": {
+      "intro": {
+        "title": "Introduction",
+        "content": "MyScrobble.fm is a personal music analytics dashboard that helps you visualize your Spotify listening habits. We take your privacy seriously and are committed to being transparent about how we handle your data."
+      },
+      "dataCollected": {
+        "title": "What We Collect",
+        "intro": "When you use MyScrobble.fm, we access the following data from your Spotify account:",
+        "item1": "Your Spotify profile information (display name, profile picture, email)",
+        "item2": "Your listening history (recently played tracks)",
+        "item3": "Your top artists, tracks, and albums",
+        "item4": "Your saved podcasts and episodes"
+      },
+      "howWeUse": {
+        "title": "How We Use Your Data",
+        "intro": "We use your data exclusively to:",
+        "item1": "Display your personalized listening statistics and charts",
+        "item2": "Generate AI-powered music recommendations based on your taste",
+        "item3": "Help you discover concerts from artists you listen to"
+      },
+      "dataStorage": {
+        "title": "Data Storage",
+        "content": "Your listening history is stored securely in our database to provide historical analytics beyond Spotify's 50-track limit. Your data is never shared with third parties for advertising or marketing purposes."
+      },
+      "thirdParty": {
+        "title": "Third-Party Services",
+        "intro": "We use the following services to provide our features:",
+        "spotify": "For authentication and accessing your music data",
+        "supabase": "For secure database storage",
+        "gemini": "For AI-powered recommendations (your data is not stored by Google)"
+      },
+      "yourRights": {
+        "title": "Your Rights",
+        "intro": "You have full control over your data:",
+        "item1": "You can revoke MyScrobble.fm's access to your Spotify account at any time through Spotify's settings",
+        "item2": "You can request deletion of all your data stored in our system",
+        "item3": "You can export your data upon request"
+      },
+      "retention": {
+        "title": "Data Retention",
+        "content": "We retain your listening history and preferences for as long as your account is active. If you revoke access or request deletion, your data will be removed within 30 days."
+      },
+      "contact": {
+        "title": "Contact Us",
+        "content": "If you have any questions about this privacy policy or your data, please contact us at"
+      }
+    }
   },
   "teaser": {
     "tagline": "Something Amazing Is Coming",

--- a/src/messages/pt-BR.json
+++ b/src/messages/pt-BR.json
@@ -37,7 +37,7 @@
     "login": "CONECTAR COM SPOTIFY",
     "privacy": "Seu histórico de músicas permanece privado. Apenas analisamos seus dados para fornecer insights.",
     "init": {
-      "loading": "Inicializando MyScrobble...",
+      "loading": "Inicializando MyScrobble.fm...",
       "spotify": "Carregando módulo da API do Spotify",
       "ai": "Carregando recomendações de IA",
       "concerts": "Carregando descoberta de shows",
@@ -454,6 +454,7 @@
   "footer": {
     "madeWith": "Criado com",
     "by": "por",
+    "privacy": "Política de Privacidade",
     "disclaimer": "MyScrobble.fm é uma ferramenta independente de análise musical. Não tenho vínculo oficial com a Last.fm ou Spotify. O termo \"Scrobble\" é utilizado de forma descritiva para a cultura de registro de músicas que amamos.",
     "tagline": "Transformando seus dados em insights visuais"
   },
@@ -492,7 +493,7 @@
     "headlinePart1": "O show de hoje está",
     "headlineHighlight": "esgotado",
     "subheadline": "Mas você está na lista de convidados para o próximo",
-    "explanation": "MyScrobble está em acesso antecipado com vagas limitadas. Estamos trabalhando para expandir a capacidade.",
+    "explanation": "MyScrobble.fm está em acesso antecipado com vagas limitadas. Estamos trabalhando para expandir a capacidade.",
     "cta": "Garantir Meu Passe VIP",
     "emailPlaceholder": "seu@email.com",
     "successPart1": "Você está",
@@ -502,14 +503,67 @@
     "position": "#{position} na fila",
     "shareTitle": "Compartilhe com amigos",
     "shareDescription": "Ajude a gente a crescer e avance na fila",
-    "twitterText": "Acabei de descobrir o MyScrobble - um painel lindo do Spotify com recomendações de IA e descoberta de shows. Confira!",
-    "whatsappText": "Confere o MyScrobble - ele mostra suas estatísticas do Spotify, encontra shows e dá recomendações musicais com IA!",
+    "twitterText": "Acabei de descobrir o MyScrobble.fm - um painel lindo do Spotify com recomendações de IA e descoberta de shows. Confira!",
+    "whatsappText": "Confere o MyScrobble.fm - ele mostra suas estatísticas do Spotify, encontra shows e dá recomendações musicais com IA!",
     "copyLink": "Copiar Link",
     "linkCopied": "Link copiado!",
     "invalidEmail": "Por favor, insira um email válido",
     "yourPosition": "Sua Posição",
     "backToHome": "Voltar ao início",
     "signingUpAs": "Entrando como"
+  },
+  "privacy": {
+    "title": "Política de Privacidade",
+    "backToHome": "Voltar ao Início",
+    "lastUpdated": "Última atualização",
+    "lastUpdatedDate": "Janeiro de 2026",
+    "sections": {
+      "intro": {
+        "title": "Introdução",
+        "content": "MyScrobble.fm é um painel de análise musical pessoal que ajuda você a visualizar seus hábitos de audição no Spotify. Levamos sua privacidade a sério e estamos comprometidos em ser transparentes sobre como tratamos seus dados."
+      },
+      "dataCollected": {
+        "title": "O Que Coletamos",
+        "intro": "Quando você usa o MyScrobble.fm, acessamos os seguintes dados da sua conta Spotify:",
+        "item1": "Suas informações de perfil do Spotify (nome, foto, email)",
+        "item2": "Seu histórico de audição (músicas tocadas recentemente)",
+        "item3": "Seus artistas, músicas e álbuns favoritos",
+        "item4": "Seus podcasts e episódios salvos"
+      },
+      "howWeUse": {
+        "title": "Como Usamos Seus Dados",
+        "intro": "Usamos seus dados exclusivamente para:",
+        "item1": "Exibir suas estatísticas e rankings personalizados de audição",
+        "item2": "Gerar recomendações musicais com IA baseadas no seu gosto",
+        "item3": "Ajudar você a descobrir shows de artistas que você ouve"
+      },
+      "dataStorage": {
+        "title": "Armazenamento de Dados",
+        "content": "Seu histórico de audição é armazenado de forma segura em nosso banco de dados para fornecer análises históricas além do limite de 50 músicas do Spotify. Seus dados nunca são compartilhados com terceiros para fins de publicidade ou marketing."
+      },
+      "thirdParty": {
+        "title": "Serviços de Terceiros",
+        "intro": "Utilizamos os seguintes serviços para fornecer nossas funcionalidades:",
+        "spotify": "Para autenticação e acesso aos seus dados musicais",
+        "supabase": "Para armazenamento seguro no banco de dados",
+        "gemini": "Para recomendações com IA (seus dados não são armazenados pelo Google)"
+      },
+      "yourRights": {
+        "title": "Seus Direitos",
+        "intro": "Você tem controle total sobre seus dados:",
+        "item1": "Você pode revogar o acesso do MyScrobble.fm à sua conta Spotify a qualquer momento nas configurações do Spotify",
+        "item2": "Você pode solicitar a exclusão de todos os seus dados armazenados em nosso sistema",
+        "item3": "Você pode exportar seus dados mediante solicitação"
+      },
+      "retention": {
+        "title": "Retenção de Dados",
+        "content": "Mantemos seu histórico de audição e preferências enquanto sua conta estiver ativa. Se você revogar o acesso ou solicitar exclusão, seus dados serão removidos em até 30 dias."
+      },
+      "contact": {
+        "title": "Fale Conosco",
+        "content": "Se você tiver alguma dúvida sobre esta política de privacidade ou seus dados, entre em contato conosco em"
+      }
+    }
   },
   "teaser": {
     "tagline": "Algo Incrível Está Chegando",


### PR DESCRIPTION
## Summary

- Adds `/privacy` page with glass-morphism design matching existing pages
- Includes flowing organic shapes background and Framer Motion animations
- Comprehensive privacy policy covering data collection, usage, storage, and user rights
- Full i18n support (EN and PT-BR)
- Adds "Privacy Policy" link to footer

## Why

This helps establish site legitimacy for the Google Safe Browsing review, and provides transparency for users about how their data is handled.

## Test plan

- [ ] Visit `/privacy` and verify page renders correctly
- [ ] Check both EN and PT-BR translations work
- [ ] Verify footer link appears and navigates to privacy page
- [ ] Test on mobile for responsive design