### PR TITLE
Allow privacy page access in teaser mode

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -60,8 +60,8 @@ export function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // TEASER MODE: Block all routes except landing page
-  if (IS_TEASER_MODE && pathname !== '/') {
+  // TEASER MODE: Block all routes except landing page and privacy policy
+  if (IS_TEASER_MODE && pathname !== '/' && pathname !== '/privacy') {
     const url = request.nextUrl.clone();
     url.pathname = '/';
     return NextResponse.redirect(url);


### PR DESCRIPTION
## Summary
- Updates middleware to allow `/privacy` route when teaser mode is enabled
- Previously only `/` was accessible in teaser mode, now both `/` and `/privacy` work

## Test plan
- [ ] Enable teaser mode (`NEXT_PUBLIC_TEASER=true`)
- [ ] Verify landing page (`/`) is accessible
- [ ] Verify privacy page (`/privacy`) is accessible
- [ ] Verify other routes (e.g., `/dashboard`) redirect to `/`