### PR TITLE
fix: Share modal hotfixes - native mobile share & pre-generation

### DIFF
--- a/src/components/share/ShareModal.tsx
+++ b/src/components/share/ShareModal.tsx
@@ -46,7 +46,7 @@ export function ShareModal() {
   const locale = useLocale();
   const colors = shareColorThemes[currentTheme];
 
-  const { isDownloading, canNativeShare, error, downloadImage, shareImage } = useShareImage(
+  const { isDownloading, isPreGenerating, canNativeShare, error, downloadImage, shareImage } = useShareImage(
     {
       type: currentData?.type || 'dashboard',
       data: currentData?.data || {},
@@ -152,7 +152,7 @@ export function ShareModal() {
             <div className="px-4 pb-4 sm:px-6 sm:pb-5 space-y-3">
               <motion.button
                 onClick={handleShare}
-                disabled={isDownloading}
+                disabled={isDownloading || isPreGenerating}
                 whileHover={{ scale: 1.02 }}
                 whileTap={{ scale: 0.98 }}
                 className="w-full py-3 sm:py-4 rounded-xl sm:rounded-2xl font-semibold text-white transition-all cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 text-sm sm:text-base"
@@ -161,14 +161,14 @@ export function ShareModal() {
                   boxShadow: `0 4px 20px ${colors.glow}`,
                 }}
               >
-                {isDownloading ? (
+                {isDownloading || isPreGenerating ? (
                   <>
                     <motion.div
                       animate={{ rotate: 360 }}
                       transition={{ duration: 1, repeat: Infinity, ease: 'linear' }}
                       className="w-4 h-4 sm:w-5 sm:h-5 rounded-full border-2 border-white border-t-transparent"
                     />
-                    {t('generating')}
+                    {isPreGenerating ? t('preparing') : t('generating')}
                   </>
                 ) : canNativeShare ? (
                   <>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -477,6 +477,7 @@
     "share": "Share",
     "downloadButton": "Download for Instagram",
     "generating": "Generating...",
+    "preparing": "Preparing...",
     "optimizedFor": "Optimized for Instagram Stories",
     "cards": {
       "nowPlaying": "Now Playing",

--- a/src/messages/pt-BR.json
+++ b/src/messages/pt-BR.json
@@ -477,6 +477,7 @@
     "share": "Compartilhar",
     "downloadButton": "Baixar para Instagram",
     "generating": "Gerando...",
+    "preparing": "Preparando...",
     "optimizedFor": "Otimizado para Instagram Stories",
     "cards": {
       "nowPlaying": "Tocando Agora",


### PR DESCRIPTION
## Summary

Fixes for the share modal to work correctly on both desktop and mobile:

- **Desktop**: Direct download (no native share attempt)
- **Mobile**: Native share with pre-generated image for instant sharing

## Problem

The Web Share API requires `navigator.share()` to be called synchronously within a user gesture. Our previous implementation did async image generation first, which caused the user gesture to expire by the time we called share.

## Solution

Pre-generate the image when the modal opens, so it's ready when the user clicks the share button.

## Changes

### 1. Pre-generation on Modal Open
- Image generation starts automatically when modal opens
- Cached in a ref to avoid re-generation
- Cache key ensures fresh generation when data changes

### 2. Loading States
- `isPreGenerating` state tracks background generation
- Button shows "Preparing..." while generating
- Button disabled until image is ready

### 3. Mobile Detection
- Only attempt native share on actual mobile devices (touch + mobile UA)
- Desktop always uses direct download

### 4. Fallback Behavior
- If native share fails for any reason, falls back to download
- User cancellation (AbortError) is handled gracefully

### 5. Translations
- Added "preparing" translation key for both en and pt-BR

## Test Plan
- [ ] Desktop: Open modal → shows "Preparing..." → then "Download" → click downloads image
- [ ] Mobile: Open modal → shows "Preparing..." → then "Share" → click opens native share sheet
- [ ] Verify image is only generated once per modal open
- [ ] Verify fallback to download works if share fails

🤖 Generated with [Claude Code](https://claude.ai/code)