### PR TITLE
perf: Speed Insights optimizations + history card fix

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,7 @@ const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 
 const nextConfig: NextConfig = {
   images: {
+    formats: ['image/avif', 'image/webp'],
     remotePatterns: [
       {
         protocol: 'https',

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -5,14 +5,23 @@ import { useQuery } from '@tanstack/react-query';
 import { motion, useInView } from 'framer-motion';
 import Image from 'next/image';
 import Link from 'next/link';
+import dynamic from 'next/dynamic';
 import { OnTourBadge } from '@/components/ui/OnTourBadge';
 import { PlayCountBadge } from '@/components/ui/PlayCountBadge';
-import { UpcomingConcerts } from '@/components/dashboard/UpcomingConcerts';
-import { MoodAnalysis } from '@/components/dashboard/MoodAnalysis';
 import { useTourStatusBatch } from '@/hooks/useTourStatus';
 import { useGeolocation } from '@/hooks/useGeolocation';
 import { useTranslations } from 'next-intl';
 import { ShareProvider, ShareModal } from '@/components/share';
+
+// Lazy load below-the-fold components for better initial load performance
+const UpcomingConcerts = dynamic(
+  () => import('@/components/dashboard/UpcomingConcerts').then(mod => ({ default: mod.UpcomingConcerts })),
+  { ssr: false }
+);
+const MoodAnalysis = dynamic(
+  () => import('@/components/dashboard/MoodAnalysis').then(mod => ({ default: mod.MoodAnalysis })),
+  { ssr: false }
+);
 
 interface NowPlayingData {
   isPlaying: boolean;
@@ -139,7 +148,7 @@ async function fetchEnrichedStats(): Promise<EnrichedStats> {
   };
 }
 
-// Scroll reveal section wrapper
+// Scroll reveal section wrapper - optimized for performance
 function RevealSection({
   children,
   className,
@@ -155,9 +164,9 @@ function RevealSection({
   return (
     <motion.section
       ref={ref}
-      initial={{ opacity: 0, y: 60 }}
-      animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 60 }}
-      transition={{ duration: 0.7, delay, ease: 'easeOut' }}
+      initial={{ opacity: 0, y: 30 }}
+      animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 30 }}
+      transition={{ duration: 0.5, delay, ease: 'easeOut' }}
       className={className}
     >
       {children}
@@ -375,21 +384,21 @@ export default function DashboardPage() {
               value={enrichedStats?.totalTracks || 0}
               label={t('stats.tracksPlayed')}
               color="#8B5CF6"
-              delay={0.1}
+              delay={0.05}
             />
             <StatItem
               value={enrichedStats?.peakHour !== undefined ? formatHourNumber(enrichedStats.peakHour) : 0}
               label={t('stats.peakHour')}
               suffix={enrichedStats?.peakHour !== undefined ? (enrichedStats.peakHour >= 12 ? 'PM' : 'AM') : ''}
               color="#F59E0B"
-              delay={0.2}
+              delay={0.1}
             />
             <StatItem
               value={Math.round((enrichedStats?.totalMinutes || 0) / 28)}
               label={t('stats.avgPerDay')}
               suffix="min"
               color="#EC4899"
-              delay={0.3}
+              delay={0.15}
             />
           </div>
         </div>
@@ -655,9 +664,9 @@ function StatItem({
   return (
     <motion.div
       ref={ref}
-      initial={{ opacity: 0, y: 30 }}
-      animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 30 }}
-      transition={{ duration: 0.6, delay }}
+      initial={{ opacity: 0, y: 20 }}
+      animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
+      transition={{ duration: 0.4, delay }}
     >
       <p className="text-5xl md:text-7xl font-black mb-2" style={{ color }}>
         {displayValue.toLocaleString()}
@@ -688,9 +697,9 @@ function ArtistCard({
   return (
     <motion.div
       ref={ref}
-      initial={{ opacity: 0, y: 40 }}
-      animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 40 }}
-      transition={{ duration: 0.6, delay }}
+      initial={{ opacity: 0, y: 20 }}
+      animate={isInView ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
+      transition={{ duration: 0.4, delay }}
       className="group relative"
     >
       <div className="relative aspect-square rounded-2xl overflow-hidden mb-4">
@@ -757,9 +766,9 @@ function TrackRow({
       href={track.spotifyUrl}
       target="_blank"
       rel="noopener noreferrer"
-      initial={{ opacity: 0, x: 20 }}
-      animate={isInView ? { opacity: 1, x: 0 } : { opacity: 0, x: 20 }}
-      transition={{ duration: 0.5, delay }}
+      initial={{ opacity: 0, x: 15 }}
+      animate={isInView ? { opacity: 1, x: 0 } : { opacity: 0, x: 15 }}
+      transition={{ duration: 0.35, delay }}
       className="group flex items-center gap-4 py-4 px-4 -mx-4 rounded-xl border-b border-transparent hover:border-transparent hover:bg-white/70 dark:hover:bg-white/10 hover:backdrop-blur-sm hover:shadow-sm transition-all"
     >
       <span className="text-3xl font-black text-muted-foreground/30 w-12 group-hover:text-[#1DB954] transition-colors">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,12 +10,14 @@ const inter = Inter({
   variable: '--font-inter',
   subsets: ['latin'],
   weight: ['400', '500', '600', '700', '800'],
+  display: 'swap',
 });
 
 const ibmPlexMono = IBM_Plex_Mono({
   variable: '--font-ibm-plex-mono',
   subsets: ['latin'],
   weight: ['400', '500', '600', '700'],
+  display: 'swap',
 });
 
 export const metadata: Metadata = {

--- a/src/components/share/cards/HistoryShareCard.tsx
+++ b/src/components/share/cards/HistoryShareCard.tsx
@@ -45,7 +45,7 @@ export function HistoryShareCard({ data, theme = 'green' }: HistoryShareCardProp
               color: '#8a8a8a',
             }}
           >
-            {data.recentTracks.length} {t('cards.tracksRecently')}
+            {tracks.length} {t('cards.tracksRecently')}
           </p>
         </div>
 

--- a/src/components/share/satori/SatoriHistoryCard.tsx
+++ b/src/components/share/satori/SatoriHistoryCard.tsx
@@ -49,7 +49,7 @@ export function SatoriHistoryCard({ data, colors, t }: SatoriHistoryCardProps) {
               color: '#8a8a8a',
             }}
           >
-            {data.recentTracks.length} {t.tracksRecently}
+            {tracks.length} {t.tracksRecently}
           </span>
         </div>
 


### PR DESCRIPTION
## Summary
- Add `display: 'swap'` to fonts for faster First Contentful Paint
- Enable AVIF/WebP image formats for smaller payloads
- Lazy load below-fold components (UpcomingConcerts, MoodAnalysis)
- Reduce animation durations and offsets for snappier perceived performance
- Fix history share card showing "9 tracks recently" when only 5 are displayed

## Test plan
- [ ] Run Lighthouse on dashboard page, verify improved FCP/LCP scores
- [ ] Check Network tab for WebP/AVIF images
- [ ] Verify animations still feel smooth but snappier
- [ ] Test history share card shows "5 tracks recently"

🤖 Generated with [Claude Code](https://claude.com/claude-code)